### PR TITLE
Fix deprecation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.0.0",
+  "version": "6.0.1",
   "name": "conserto/pomm-bundle",
   "type": "symfony-bundle",
   "description": "The Symfony bundle for Pomm",

--- a/sources/lib/DependencyInjection/PommExtension.php
+++ b/sources/lib/DependencyInjection/PommExtension.php
@@ -15,7 +15,7 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
 /**
@@ -34,6 +34,7 @@ class PommExtension extends Extension
     /**
      * load
      *
+     * @throws \Exception
      * @see Extension
      */
     public function load(array $configs, ContainerBuilder $container): void


### PR DESCRIPTION
Fix deprecation : The "Symfony\Component\HttpKernel\DependencyInjection\Extension" class is considered internal since Symfony 7.1, to be deprecated in 8.1; use Symfony\Component\DependencyInjection\Extension\Extension instead. It may change without further notice. You should not use it from "PommProject\PommBundle\DependencyInjection\PommExtension".